### PR TITLE
[PR] 컬럼 용량 수정

### DIFF
--- a/src/main/java/org/example/autoreview/domain/codepost/entity/CodePost.java
+++ b/src/main/java/org/example/autoreview/domain/codepost/entity/CodePost.java
@@ -39,10 +39,10 @@ public class CodePost extends BaseEntity {
 
     private LocalDate reviewDay;
 
-    @Column(length = 2000)
+    @Column(length = 4000)
     private String description;
 
-    @Column(length = 1000)
+    @Column(length = 4000, columnDefinition = "LONGTEXT")
     private String code;
 
     @Enumerated(EnumType.STRING)


### PR DESCRIPTION
- MySql 상에서 UTF-8로 설정되어있어서 글자당 4byte로 잡힘