### PR TITLE
[PR] 배포 서버 DB 와의 데이터 불일치 해결

### DIFF
--- a/src/main/java/org/example/autoreview/domain/member/entity/MemberConverter.java
+++ b/src/main/java/org/example/autoreview/domain/member/entity/MemberConverter.java
@@ -4,10 +4,10 @@ import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 
 @Converter
-public class MemberConverter implements AttributeConverter<Role, Integer> {
+public class MemberConverter implements AttributeConverter<Role, Byte> {
 
     @Override
-    public Integer convertToDatabaseColumn(Role attribute) {
+    public Byte convertToDatabaseColumn(Role attribute) {
         if(Role.USER.equals(attribute)){
             return 1;
         }
@@ -15,7 +15,7 @@ public class MemberConverter implements AttributeConverter<Role, Integer> {
     }
 
     @Override
-    public Role convertToEntityAttribute(Integer dbData) {
+    public Role convertToEntityAttribute(Byte dbData) {
         if(dbData == 1){
             return Role.USER;
         }

--- a/src/main/resources/db/migration/V4.1__if_not_exist_comment_table_then_create.sql
+++ b/src/main/resources/db/migration/V4.1__if_not_exist_comment_table_then_create.sql
@@ -1,0 +1,35 @@
+CREATE TABLE IF NOT EXISTS code_post_comment (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    writer_id BIGINT NOT NULL,
+    writer_nick_name VARCHAR(255) NOT NULL,
+    writer_email VARCHAR(255) NOT NULL,
+    mention_nick_name VARCHAR(255),
+    mention_email VARCHAR(255),
+    body TEXT NOT NULL,
+    is_public BOOLEAN NOT NULL DEFAULT TRUE,
+    code_post_id BIGINT,
+    parent_id BIGINT,
+    create_date DATETIME DEFAULT CURRENT_TIMESTAMP,
+    update_date DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (code_post_id) REFERENCES code_post(id),
+    FOREIGN KEY (parent_id) REFERENCES code_post_comment(id)
+);
+
+CREATE TABLE IF NOT EXISTS til_post_comment (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    writer_id BIGINT NOT NULL,
+    writer_nick_name VARCHAR(255) NOT NULL,
+    writer_email VARCHAR(255) NOT NULL,
+    mention_nick_name VARCHAR(255),
+    mention_email VARCHAR(255),
+    body TEXT NOT NULL,
+    is_public BOOLEAN NOT NULL DEFAULT TRUE,
+    til_post_id BIGINT,
+    parent_id BIGINT,
+    create_date DATETIME DEFAULT CURRENT_TIMESTAMP,
+    update_date DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (til_post_id) REFERENCES tilpost(til_post_id),
+    FOREIGN KEY (parent_id) REFERENCES til_post_comment(id)
+);
+
+

--- a/src/main/resources/db/migration/V4.2__if_member_email_not_unique_then_update_to_unique.sql
+++ b/src/main/resources/db/migration/V4.2__if_member_email_not_unique_then_update_to_unique.sql
@@ -1,0 +1,9 @@
+-- 중복 이메일이 있는지 확인
+SELECT email
+FROM member
+GROUP BY email
+HAVING COUNT(*) > 1;
+
+-- 조건에 따라 UNIQUE 제약 조건 추가
+ALTER TABLE member
+    ADD CONSTRAINT UKmbmcqelty0fbrvxp1q58dn57t UNIQUE (email);


### PR DESCRIPTION
- member email UNIQUE 설정
- code_post_comment & tilpost_comment 테이블 없을 경우 생성
- member table의 role 컬럼 타입 int 에서 tinyint로 변경