### PR TITLE
[PR] 알림 crud 기능 변경 및 fcm 전송 방식 변경

### DIFF
--- a/src/main/java/org/example/autoreview/domain/codepost/service/CodePostDtoService.java
+++ b/src/main/java/org/example/autoreview/domain/codepost/service/CodePostDtoService.java
@@ -58,7 +58,7 @@ public class CodePostDtoService {
 
     public Long postUpdate(CodePostUpdateRequestDto requestDto, String email) {
         CodePost codePost = codePostService.update(requestDto, email);
-        boolean notificationExists = notificationService.existsById(requestDto.getId());
+        boolean notificationExists = notificationService.existsByCodePostId(requestDto.getId());
 
         if (notificationExists) {
             if (requestDto.getReviewDay() == null) {
@@ -75,7 +75,7 @@ public class CodePostDtoService {
     }
 
     public Long postDelete(Long id, String email){
-        if (notificationService.existsById(id)) {
+        if (notificationService.existsByCodePostId(id)) {
             notificationService.delete(email,id);
         }
         return codePostService.delete(id, email);

--- a/src/main/java/org/example/autoreview/domain/fcm/service/FcmTokenService.java
+++ b/src/main/java/org/example/autoreview/domain/fcm/service/FcmTokenService.java
@@ -3,7 +3,8 @@ package org.example.autoreview.domain.fcm.service;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.Notification;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.example.autoreview.domain.fcm.dto.request.FcmTokenSaveRequestDto;
@@ -13,9 +14,6 @@ import org.example.autoreview.domain.member.entity.Member;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
-
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -32,24 +30,26 @@ public class FcmTokenService {
 
     public void pushNotification(List<FcmToken> fcmTokens, String title, String content) {
         log.info("pushNotification 트랜잭션 존재 여부: {}", TransactionSynchronizationManager.isActualTransactionActive());
-        for (FcmToken fcmToken : fcmTokens) { CompletableFuture.runAsync(() -> {
-            try {
-                Message message = Message.builder()
-                        .setNotification(Notification.builder()
-                                .setTitle(title)
-                                .setBody(content)
-                                .build())
-                        .setToken(fcmToken.getToken())
-                        .build();
 
-                FirebaseMessaging.getInstance().send(message);
-                fcmToken.updateDate();
+        for (FcmToken fcmToken : fcmTokens) {
+            CompletableFuture.runAsync(() -> {
+                try {
+                    Message message = Message.builder()
+                            .putData("title", title)
+                            .putData("body", content)
+                            .setToken(fcmToken.getToken())
+                            .build();
 
-            } catch (FirebaseMessagingException e) {
-                log.error("Failed to send message to device {}: {}", fcmToken.getId(), e.getMessage());
-            } catch (Exception e) {
-                log.error("An unexpected error occurred: {}", e.getMessage());
-            }});
+                    FirebaseMessaging.getInstance().send(message);
+                    fcmToken.updateDate();
+
+                } catch (FirebaseMessagingException e) {
+                    log.error("Failed to send message to device {}: {}", fcmToken.getId(), e.getMessage());
+                } catch (Exception e) {
+                    log.error("An unexpected error occurred: {}", e.getMessage());
+                }
+            });
         }
     }
+
 }

--- a/src/main/java/org/example/autoreview/domain/notification/entity/Notification.java
+++ b/src/main/java/org/example/autoreview/domain/notification/entity/Notification.java
@@ -1,6 +1,16 @@
 package org.example.autoreview.domain.notification.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,8 +20,6 @@ import org.example.autoreview.domain.member.entity.Member;
 import org.example.autoreview.domain.notification.enums.NotificationStatus;
 import org.example.autoreview.global.common.basetime.BaseEntity;
 import org.hibernate.annotations.ColumnDefault;
-
-import java.time.LocalDate;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -64,6 +72,7 @@ public class Notification extends BaseEntity {
 
     public void update(CodePost codePost, NotificationStatus status) {
         this.status = status;
+        this.isChecked = false;
         this.content = codePost.getTitle();
         this.executeTime = codePost.getReviewDay();
     }

--- a/src/main/java/org/example/autoreview/domain/notification/entity/NotificationRepository.java
+++ b/src/main/java/org/example/autoreview/domain/notification/entity/NotificationRepository.java
@@ -2,12 +2,18 @@ package org.example.autoreview.domain.notification.entity;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import org.example.autoreview.domain.notification.dto.response.NotificationResponseDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface NotificationRepository extends JpaRepository<Notification,Long> {
+
+    boolean existsByCodePostId(@Param("codePostId") Long codePostId);
+
+    @Query("SELECT n FROM Notification n WHERE n.codePostId = :codePostId")
+    Optional<Notification> findByCodePostId(@Param("codePostId") Long codePostId);
 
     @Query("SELECT n FROM Notification n WHERE n.member.id = :memberId")
     List<Notification> findAllByMemberId(@Param("memberId") Long memberId);

--- a/src/main/java/org/example/autoreview/domain/notification/service/NotificationService.java
+++ b/src/main/java/org/example/autoreview/domain/notification/service/NotificationService.java
@@ -43,6 +43,10 @@ public class NotificationService {
         return notificationRepository.existsById(id);
     }
 
+    public boolean existsByCodePostId(Long id) {
+        return notificationRepository.existsByCodePostId(id);
+    }
+
     public Notification findEntityById(Long id) {
         return notificationRepository.findById(id).orElseThrow(
                 () -> new NotFoundException(ErrorCode.NOT_FOUND_NOTIFICATION)
@@ -80,7 +84,7 @@ public class NotificationService {
 
     @Transactional
     public void update(String email, CodePost codePost, NotificationStatus status) {
-        Notification notification = notificationRepository.findById(codePost.getId()).orElseThrow(
+        Notification notification = notificationRepository.findByCodePostId(codePost.getId()).orElseThrow(
                 () -> new NotFoundException(ErrorCode.NOT_FOUND_NOTIFICATION)
         );
         userValidator(email, notification);
@@ -89,7 +93,7 @@ public class NotificationService {
 
     @Transactional
     public void delete(String email, Long id) {
-        Notification notification = notificationRepository.findById(id).orElseThrow(
+        Notification notification = notificationRepository.findByCodePostId(id).orElseThrow(
                 () -> new NotFoundException(ErrorCode.NOT_FOUND_NOTIFICATION)
         );
         userValidator(email,notification);


### PR DESCRIPTION
- 알림 entity code post id로 조회하도록 변경
- fcm 전송 시 중복 알림 요청을 없애기 위해 setNotification이 아닌 putData로 변경
- setNotfication은 자동으로 객체를 전송하기 때문에 프론트에서 알림 전송을 수동으로 1번, 백에서 자동으로 알림 전송 1번 총 2번의 중복 요청이 발생했었음