### PR TITLE
[PR] 단일 조회 시 결과 값이 1개 이상인 문제 해결

### DIFF
--- a/src/main/java/org/example/autoreview/domain/codepost/dto/request/CodePostUpdateRequestDto.java
+++ b/src/main/java/org/example/autoreview/domain/codepost/dto/request/CodePostUpdateRequestDto.java
@@ -27,7 +27,7 @@ public class CodePostUpdateRequestDto {
     @Schema(description = "복습일 설정", example = "2024-10-11")
     private final LocalDate reviewDay;
 
-    @Schema(description = "사용 언어", example = "c++")
+    @Schema(description = "사용 언어", example = "cpp")
     private final String language;
 
     @Schema(description = "코드", example = "import test")

--- a/src/main/java/org/example/autoreview/domain/codepost/entity/CodePostRepository.java
+++ b/src/main/java/org/example/autoreview/domain/codepost/entity/CodePostRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface CodePostRepository extends JpaRepository<CodePost, Long> {
 
-    @Query("SELECT c FROM CodePost c WHERE c.id = :id AND c.writerId = :memberId OR c.isPublic = TRUE")
+    @Query("SELECT c FROM CodePost c WHERE c.id = :id AND (c.writerId = :memberId OR c.isPublic = TRUE)")
     Optional<CodePost> findByIdIsPublic(@Param("id") Long id, @Param("memberId") Long memberId);
 
     @Query("SELECT new org.example.autoreview.domain.codepost.dto.response.CodePostThumbnailResponseDto(c,m) " +


### PR DESCRIPTION
- 쿼리문에서 and와 or의 순서가 잘못됨 괄호를 통해 해결