### PR TITLE
refactor: git actions 가상 머신을 통해 테스트 성공 시도

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: MySQL 연결 확인
         run: |
           sudo apt-get update && sudo apt-get install -y mysql-client
-          mysql -htest -P3306 -utester -p${{ secrets.TEST_DB_PASSWORD}} -e "SHOW DATABASES;"
+          mysql -hlocalhost -P3306 -utester -p${{ secrets.TEST_DB_PASSWORD}} -e "SHOW DATABASES;"
 
       - name: Redis 연결 확인
         run: |


### PR DESCRIPTION
- GitHub Actions의 services에서 설정한 MySQL 컨테이너의 호스트 이름은 localhost 또는 127.0.0.1로 접근해야 하는데 "-htest" 라고 작성해서 "test"라는 별도 호스트 이름을 찾으려고 했기 때문에 실패함