### PR TITLE
refactor: test active profile 설정 제거 및 ci.yml 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,17 +49,18 @@ jobs:
           sudo apt-get update && sudo apt-get install -y redis-tools
           redis-cli -h localhost ping
 
-      - name: Copy private test resources
-        run: ./gradlew copyTestYml --no-daemon
+      - name: Copy private ci resources
+        run: ./gradlew copyCiYml --no-daemon
 
       - name: 테스트 실행
         run: ./gradlew test
         env:
+          SPRING_PROFILES_ACTIVE: ci
           DB_HOST: 127.0.0.1
           DB_PORT: 3306
           DB_NAME: test
           DB_USER: tester
-          DB_PASSWORD: ${{ secrets.TEST_DB_PASSWORD}}
+          DB_PASSWORD: ${{ secrets.TEST_DB_PASSWORD }}
           REDIS_HOST: 127.0.0.1
           REDIS_PORT: 6379
 

--- a/build.gradle
+++ b/build.gradle
@@ -73,9 +73,9 @@ tasks.register('copyYml', Copy) {
     }
 }
 
-tasks.register('copyTestYml', Copy) {
+tasks.register('copyCiYml', Copy) {
     from 'security_setting'
-    include 'application-test.yml'
+    include 'application-ci.yml'
     into 'src/test/resources'
 }
 

--- a/src/test/java/org/example/autoreview/AutoreviewApplicationTests.java
+++ b/src/test/java/org/example/autoreview/AutoreviewApplicationTests.java
@@ -2,9 +2,7 @@ package org.example.autoreview;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("test")
 @SpringBootTest
 class AutoreviewApplicationTests {
 

--- a/src/test/java/org/example/autoreview/domain/bookmark/CodePostBookmark/service/CodePostBookmarkServiceIntegrationTest.java
+++ b/src/test/java/org/example/autoreview/domain/bookmark/CodePostBookmark/service/CodePostBookmarkServiceIntegrationTest.java
@@ -1,5 +1,8 @@
 package org.example.autoreview.domain.bookmark.CodePostBookmark.service;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.springframework.data.domain.PageRequest.of;
+
 import org.example.autoreview.domain.bookmark.CodePostBookmark.dto.request.CodePostBookmarkSaveRequestDto;
 import org.example.autoreview.domain.bookmark.CodePostBookmark.dto.response.CodePostBookmarkListResponseDto;
 import org.example.autoreview.domain.bookmark.CodePostBookmark.entity.CodePostBookmarkRepository;
@@ -14,12 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.springframework.data.domain.PageRequest.of;
-
-@ActiveProfiles("test")
 @SpringBootTest
 class CodePostBookmarkServiceIntegrationTest {
 

--- a/src/test/java/org/example/autoreview/domain/codepost/service/CodePostServiceIntegrationTest.java
+++ b/src/test/java/org/example/autoreview/domain/codepost/service/CodePostServiceIntegrationTest.java
@@ -1,5 +1,9 @@
 package org.example.autoreview.domain.codepost.service;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.LocalDate;
 import org.example.autoreview.domain.bookmark.CodePostBookmark.service.CodePostBookmarkCommand;
 import org.example.autoreview.domain.codepost.dto.request.CodePostSaveRequestDto;
 import org.example.autoreview.domain.codepost.dto.request.CodePostUpdateRequestDto;
@@ -17,14 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
-import java.time.LocalDate;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-@ActiveProfiles("test")
 @SpringBootTest
 public class CodePostServiceIntegrationTest {
 

--- a/src/test/java/org/example/autoreview/domain/comment/codepost/service/CodePostCommentServiceIntegrationTest.java
+++ b/src/test/java/org/example/autoreview/domain/comment/codepost/service/CodePostCommentServiceIntegrationTest.java
@@ -4,9 +4,7 @@ import org.example.autoreview.domain.codepost.service.CodePostCommand;
 import org.example.autoreview.domain.member.service.MemberCommand;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("test")
 @SpringBootTest
 public class CodePostCommentServiceIntegrationTest {
 


### PR DESCRIPTION
- ci 와 로컬 환경에서 설정 파일 차이를 두기 위해 @ActiveProfile() 어노테이션 삭제

- 앞으로는 로컬환경에서 테스트하려면 직접 test 환경으로 설정해야함