### PR TITLE
[Bugfix] DB 불일치 해결

### DIFF
--- a/src/main/java/org/example/autoreview/domain/fcm/entity/FcmToken.java
+++ b/src/main/java/org/example/autoreview/domain/fcm/entity/FcmToken.java
@@ -10,6 +10,9 @@ import org.example.autoreview.domain.member.entity.Member;
 
 @Getter
 @NoArgsConstructor
+@Table(uniqueConstraints = {@UniqueConstraint(name = "uq_fcm_token",
+        columnNames = {"token"})}
+)
 @Entity
 public class FcmToken {
 

--- a/src/main/resources/db/migration/V10.1__alter_fcm_token_add_unique_token.sql
+++ b/src/main/resources/db/migration/V10.1__alter_fcm_token_add_unique_token.sql
@@ -1,6 +1,6 @@
--- 1. token 컬럼 NOT NULL 제약 추가 (있다면 무시)
-ALTER TABLE fcm_token
-    MODIFY COLUMN token VARCHAR(255) NOT NULL;
+-- -- 1. token 컬럼 NOT NULL 제약 추가 (있다면 무시)
+-- ALTER TABLE fcm_token
+--     MODIFY COLUMN token VARCHAR(255) NOT NULL;
 
 -- 2. token 컬럼에 UNIQUE 제약 추가
 ALTER TABLE fcm_token


### PR DESCRIPTION
- JPA 가 자동으로 랜덤한 이름의 유니크 이름을 사용하는 반면에 Flyway는 uq_fcm_token 라는 이름으로 지정하여 생성하기 때문에 불일치 발생